### PR TITLE
Download gdtoolkit when it is not found [MISSPELL]

### DIFF
--- a/addons/format_on_save/format_on_save.gd
+++ b/addons/format_on_save/format_on_save.gd
@@ -30,6 +30,21 @@ func on_resource_saved(resource: Resource):
 		if current_script == script:
 			var filepath: String = ProjectSettings.globalize_path(resource.resource_path)
 
+			# Download and manage gdtookit when it is not found globally
+			var exec_path: String = "gdformat"
+			if OS.execute(exec_path, ["--version"]) != SUCCESS:
+				var major_version: int = Engine.get_version_info().major
+				var python_path: String = (
+					"%s/python"
+					% ProjectSettings.globalize_path(get_script().resource_path.get_base_dir())
+				)
+				exec_path = "%s/bin/gdformat" % python_path
+				if not FileAccess.file_exists(exec_path):
+					OS.execute(
+						"pip3",
+						["install", "gdtoolkit==%d.*" % major_version, "--target=%s" % python_path]
+					)
+
 			# Run gdformat
 			var exit_code = OS.execute("gdformat", [filepath])
 


### PR DESCRIPTION
fix #2

- Prioritize the pre-installed [gdtoolkit](https://github.com/Scony/godot-gdscript-toolkit).
- Download gdtoolkit to the subdirectory of the current plugin via [pip3](https://pypi.org/project/pip) when it is not found globally.