### PR TITLE
fix: emit text changed signal

### DIFF
--- a/addons/format_on_save/format_on_save.gd
+++ b/addons/format_on_save/format_on_save.gd
@@ -56,6 +56,8 @@ static func reload_script(text_edit: TextEdit, source_code: String) -> void:
 
 	text_edit.tag_saved_version()
 
+	text_edit.text_changed.emit()
+
 
 # For this workaround to work, we need to disable the "Reload/Resave" pop-up
 func activate_auto_reload_setting():


### PR DESCRIPTION
When saving the script, there is a high probability that the safe lines will not refresh.
After emitting the signal "text_changed", it's resolved.
<img width="190" alt="Snipaste_2024-10-16_01-13-18" src="https://github.com/user-attachments/assets/68065a61-30ea-4258-9d92-1703458b3756">
